### PR TITLE
Upgrade script for 10.3 and later

### DIFF
--- a/EnergyCostCalculator/EnergyCostCalculator.py
+++ b/EnergyCostCalculator/EnergyCostCalculator.py
@@ -18,6 +18,7 @@ def CleanupDeadlineEventListener(eventListener):
 class EnergyCostCalculator(DeadlineEventListener):
     def __init__(self):
         """Sets up callbacks and imports config."""
+        super().__init__() # Required in Deadline 10.3 and later
         self.OnJobFinishedCallback += self.OnJobFinished
         self.OnSlaveRenderingCallback += self.OnSlaveRendering
         self.config = RepositoryUtils.GetEventPluginConfig("EnergyCostCalculator")


### PR DESCRIPTION
Missing super() for 10.3 and later compatibility

https://docs.thinkboxsoftware.com/products/deadline/10.3/1_User%20Manual/manual/event-plugins.html#py-file